### PR TITLE
Refactor internals of EventTracker; add total count tracker test

### DIFF
--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/AmplifyStateTracker.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/AmplifyStateTracker.java
@@ -154,10 +154,10 @@ public final class AmplifyStateTracker {
 
     public AmplifyStateTracker notifyEventTriggered(@NonNull final IEvent event) {
         logger.d("Triggered Event: " + event);
-        totalCountTracker.eventTriggered(event);
-        firstTimeTracker.eventTriggered(event);
-        lastTimeTracker.eventTriggered(event);
-        lastVersionTracker.eventTriggered(event);
+        totalCountTracker.notifyEventTriggered(event);
+        firstTimeTracker.notifyEventTriggered(event);
+        lastTimeTracker.notifyEventTriggered(event);
+        lastVersionTracker.notifyEventTriggered(event);
         return this;
     }
 

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/IntegratedEvent.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/IntegratedEvent.java
@@ -61,7 +61,7 @@ public enum IntegratedEvent implements IEvent {
             final ITrackedEvent trackedEvent = new TrackedEvent(this, new WarmUpDaysCheck(ONE_WEEK));
 
             if (!settings.hasEventValue(trackedEvent)) {
-                settings.writeEventValue(trackedEvent, ClockUtil.getCurrentTimeMillis());
+                settings.writeTrackingValue(trackedEvent, ClockUtil.getCurrentTimeMillis());
             }
         }
     }

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/Settings.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/Settings.java
@@ -40,7 +40,7 @@ public class Settings<T> implements ISettings<T> {
                 .getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
     }
 
-    public void writeEventValue(@NonNull final ITrackedEvent event, final T value) {
+    public void writeTrackingValue(@NonNull final ITrackedEvent event, final T value) {
 
         SharedPreferences.Editor editor = sharedPreferences.edit();
 
@@ -63,7 +63,7 @@ public class Settings<T> implements ISettings<T> {
     }
 
     @Nullable
-    public T getEventValue(@NonNull final ITrackedEvent trackedEvent) {
+    public T readTrackingValue(@NonNull final ITrackedEvent trackedEvent) {
         final Map<String, ?> map = sharedPreferences.getAll();
 
         for (Map.Entry<String, ?> entry : map.entrySet()) {

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/interfaces/ISettings.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/interfaces/ISettings.java
@@ -21,10 +21,10 @@ import android.support.annotation.Nullable;
 
 public interface ISettings<T> {
 
-    void writeEventValue(@NonNull final ITrackedEvent event, final T value);
+    void writeTrackingValue(@NonNull final ITrackedEvent event, final T value);
 
     @Nullable
-    T getEventValue(@NonNull final ITrackedEvent trackedEvent);
+    T readTrackingValue(@NonNull final ITrackedEvent trackedEvent);
 
     boolean hasEventValue(@NonNull final ITrackedEvent trackedEvent);
 

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/EventTracker.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/EventTracker.java
@@ -45,7 +45,6 @@ public abstract class EventTracker<T> {
     protected abstract T computeUpdatedTrackingValue(@NonNull final T cachedEventValue);
 
     public EventTracker(@NonNull final ILogger logger, @NonNull final ISettings<T> settings, @NonNull final IApplicationInfoProvider applicationInfoProvider) {
-        super();
         this.logger = logger;
         this.settings = settings;
         this.applicationInfoProvider = applicationInfoProvider;

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/EventTracker.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/EventTracker.java
@@ -44,7 +44,6 @@ public abstract class EventTracker<T> {
     @NonNull
     protected abstract T computeUpdatedTrackingValue(@NonNull final T cachedEventValue);
 
-
     public EventTracker(
             @NonNull final ILogger logger,
             @NonNull final ISettings<T> settings,

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/FirstTimeTracker.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/FirstTimeTracker.java
@@ -20,13 +20,12 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
+import com.github.stkent.amplify.ILogger;
 import com.github.stkent.amplify.tracking.ApplicationInfoProvider;
 import com.github.stkent.amplify.tracking.ClockUtil;
 import com.github.stkent.amplify.tracking.Settings;
 import com.github.stkent.amplify.tracking.interfaces.IApplicationInfoProvider;
-import com.github.stkent.amplify.ILogger;
 import com.github.stkent.amplify.tracking.interfaces.ISettings;
-import com.github.stkent.amplify.tracking.interfaces.ITrackedEvent;
 
 public class FirstTimeTracker extends EventTracker<Long> {
 
@@ -39,19 +38,21 @@ public class FirstTimeTracker extends EventTracker<Long> {
         super(logger, settings, applicationInfoProvider);
     }
 
+    @NonNull
     @Override
-    public void eventTriggered(@NonNull final ITrackedEvent event) {
-        final Long cachedTime = getEventValue(event);
-
-        if (cachedTime == Long.MAX_VALUE) {
+    public Long computeUpdatedTrackingValue(@NonNull final Long cachedValue) {
+        if (cachedValue == Long.MAX_VALUE) {
             final Long currentTime = ClockUtil.getCurrentTimeMillis();
-            getLogger().d("FirstTimePredicate updating event value from: " + cachedTime + ", to: " + currentTime);
-            updateEventValue(event, Math.min(cachedTime, currentTime));
+            getLogger().d("FirstTimePredicate updating event value from: " + cachedValue + ", to: " + currentTime);
+            return Math.min(cachedValue, currentTime);
         }
+
+        return cachedValue;
     }
 
+    @NonNull
     @Override
-    public Long defaultValue() {
+    public Long defaultTrackingValue() {
         return Long.MAX_VALUE;
     }
 }

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/LastTimeTracker.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/LastTimeTracker.java
@@ -20,13 +20,12 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
+import com.github.stkent.amplify.ILogger;
 import com.github.stkent.amplify.tracking.ApplicationInfoProvider;
 import com.github.stkent.amplify.tracking.ClockUtil;
 import com.github.stkent.amplify.tracking.Settings;
 import com.github.stkent.amplify.tracking.interfaces.IApplicationInfoProvider;
-import com.github.stkent.amplify.ILogger;
 import com.github.stkent.amplify.tracking.interfaces.ISettings;
-import com.github.stkent.amplify.tracking.interfaces.ITrackedEvent;
 
 public class LastTimeTracker extends EventTracker<Long> {
 
@@ -39,16 +38,17 @@ public class LastTimeTracker extends EventTracker<Long> {
         super(logger, settings, applicationInfoProvider);
     }
 
+    @NonNull
     @Override
-    public void eventTriggered(@NonNull final ITrackedEvent event) {
-
+    public Long computeUpdatedTrackingValue(@NonNull final Long cachedTrackingValue) {
         final Long currentTime = ClockUtil.getCurrentTimeMillis();
         getLogger().d("LastTimePredicate updating event value to: " + currentTime);
-        updateEventValue(event, currentTime);
+        return currentTime;
     }
 
+    @NonNull
     @Override
-    public Long defaultValue() {
+    public Long defaultTrackingValue() {
         return Long.MAX_VALUE;
     }
 }

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/LastVersionTracker.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/LastVersionTracker.java
@@ -21,12 +21,11 @@ import android.content.pm.PackageManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
+import com.github.stkent.amplify.ILogger;
 import com.github.stkent.amplify.tracking.ApplicationInfoProvider;
 import com.github.stkent.amplify.tracking.Settings;
-import com.github.stkent.amplify.ILogger;
 import com.github.stkent.amplify.tracking.interfaces.IApplicationInfoProvider;
 import com.github.stkent.amplify.tracking.interfaces.ISettings;
-import com.github.stkent.amplify.tracking.interfaces.ITrackedEvent;
 
 public class LastVersionTracker extends EventTracker<String> {
 
@@ -39,19 +38,22 @@ public class LastVersionTracker extends EventTracker<String> {
         super(logger, settings, applicationInfoProvider);
     }
 
+    @NonNull
     @Override
-    public void eventTriggered(@NonNull final ITrackedEvent event) {
+    public String computeUpdatedTrackingValue(@NonNull final String cachedTrackingValue) {
         try {
             final String currentVersion = getApplicationInfoProvider().getVersionName();
             getLogger().d("LastVersionPredicate updating event value to: " + currentVersion);
-            updateEventValue(event, currentVersion);
+            return currentVersion;
         } catch (final PackageManager.NameNotFoundException e) {
             getLogger().d("Could not read current app version name.");
+            return cachedTrackingValue;
         }
     }
 
+    @NonNull
     @Override
-    public String defaultValue() {
+    public String defaultTrackingValue() {
         return "";
     }
 

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/TotalCountTracker.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/TotalCountTracker.java
@@ -20,12 +20,11 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
+import com.github.stkent.amplify.ILogger;
 import com.github.stkent.amplify.tracking.ApplicationInfoProvider;
 import com.github.stkent.amplify.tracking.Settings;
-import com.github.stkent.amplify.ILogger;
 import com.github.stkent.amplify.tracking.interfaces.IApplicationInfoProvider;
 import com.github.stkent.amplify.tracking.interfaces.ISettings;
-import com.github.stkent.amplify.tracking.interfaces.ITrackedEvent;
 
 public class TotalCountTracker extends EventTracker<Integer> {
 
@@ -38,17 +37,17 @@ public class TotalCountTracker extends EventTracker<Integer> {
         super(logger, settings, applicationInfoProvider);
     }
 
+    @NonNull
     @Override
-    public void eventTriggered(@NonNull final ITrackedEvent event) {
-
-        final Integer cachedCount = getEventValue(event);
-        final Integer updatedCount = cachedCount + 1;
-        getLogger().d("TotalCountPredicate updating event value from: " + cachedCount + ", to: " + updatedCount);
-        updateEventValue(event, updatedCount);
+    public Integer computeUpdatedTrackingValue(@NonNull final Integer cachedTrackingValue) {
+        final Integer updatedCount = cachedTrackingValue + 1;
+        getLogger().d("TotalCountPredicate updating event value from: " + cachedTrackingValue + ", to: " + updatedCount);
+        return updatedCount;
     }
 
+    @NonNull
     @Override
-    public Integer defaultValue() {
+    public Integer defaultTrackingValue() {
         return 0;
     }
 }

--- a/amplify/src/test/java/com/github/stkent/amplify/helpers/FakeSettings.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/helpers/FakeSettings.java
@@ -32,7 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * indexed first by IEvent, and then by IEventCheck. This allows for easier
  * verifications during testing.
  */
-public class MockSettings<T> implements ISettings<T> {
+public class FakeSettings<T> implements ISettings<T> {
 
     private final Map<IEvent, Map<IEventCheck, T>> mostRecentValuesWritten = new ConcurrentHashMap<>();
 

--- a/amplify/src/test/java/com/github/stkent/amplify/helpers/MockSettings.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/helpers/MockSettings.java
@@ -52,7 +52,7 @@ public class MockSettings<T> implements ISettings<T> {
     }
 
     @Override
-    public void writeEventValue(@NonNull final ITrackedEvent trackedEvent, final T value) {
+    public void writeTrackingValue(@NonNull final ITrackedEvent trackedEvent, final T value) {
         final IEvent event = trackedEvent.getEvent();
 
         if (!mostRecentValuesWritten.containsKey(event)) {
@@ -64,13 +64,13 @@ public class MockSettings<T> implements ISettings<T> {
 
     @Nullable
     @Override
-    public T getEventValue(@NonNull final ITrackedEvent trackedEvent) {
+    public T readTrackingValue(@NonNull final ITrackedEvent trackedEvent) {
         return getEventValue(trackedEvent.getEvent(), trackedEvent.getEventCheck());
     }
 
     @Override
     public boolean hasEventValue(@NonNull final ITrackedEvent trackedEvent) {
-        return getEventValue(trackedEvent) != null;
+        return readTrackingValue(trackedEvent) != null;
     }
 
 }

--- a/amplify/src/test/java/com/github/stkent/amplify/helpers/StubLogger.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/helpers/StubLogger.java
@@ -21,7 +21,7 @@ import android.support.annotation.NonNull;
 import com.github.stkent.amplify.Logger;
 import com.github.stkent.amplify.ILogger;
 
-public class StubbedLogger implements ILogger {
+public class StubLogger implements ILogger {
 
     @Override
     public void setLogLevel(@NonNull final Logger.LogLevel logLevel) {

--- a/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/FirstTimeTrackerTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/FirstTimeTrackerTest.java
@@ -21,7 +21,7 @@ import android.support.annotation.NonNull;
 
 import com.github.stkent.amplify.helpers.BaseTest;
 import com.github.stkent.amplify.helpers.FakeSettings;
-import com.github.stkent.amplify.helpers.StubbedLogger;
+import com.github.stkent.amplify.helpers.StubLogger;
 import com.github.stkent.amplify.tracking.ClockUtil;
 import com.github.stkent.amplify.tracking.interfaces.IApplicationInfoProvider;
 import com.github.stkent.amplify.tracking.interfaces.IEvent;
@@ -52,7 +52,7 @@ public class FirstTimeTrackerTest extends BaseTest {
         fakeSettings = new FakeSettings<>();
 
         firstTimeTracker = new FirstTimeTracker(
-                new StubbedLogger(), fakeSettings,
+                new StubLogger(), fakeSettings,
                 mockApplicationInfoProvider);
 
         firstTimeTracker.trackEvent(mockEvent, mockEventCheck);

--- a/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/FirstTimeTrackerTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/FirstTimeTrackerTest.java
@@ -52,7 +52,8 @@ public class FirstTimeTrackerTest extends BaseTest {
         fakeSettings = new FakeSettings<>();
 
         firstTimeTracker = new FirstTimeTracker(
-                new StubLogger(), fakeSettings,
+                new StubLogger(),
+                fakeSettings,
                 mockApplicationInfoProvider);
 
         firstTimeTracker.trackEvent(mockEvent, mockEventCheck);
@@ -67,20 +68,19 @@ public class FirstTimeTrackerTest extends BaseTest {
         triggerEventAtTime(mockEvent, fakeEventTime);
 
         // Assert
-
-        // Check that the correct event time was saved:
         final Long savedEventTime = fakeSettings.getEventValue(mockEvent, mockEventCheck);
 
-        assertEquals("The correct time should have been recorded for this event", Long.valueOf(fakeEventTime), savedEventTime);
+        assertEquals(
+                "The correct time should have been recorded for this event",
+                Long.valueOf(fakeEventTime), savedEventTime);
     }
 
     @SuppressLint("Assert")
     @Test
-    public void testThatSecondAndSubsequentEventTimesAreNotRecorded() {
-        // Arrange Act
+    public void testThatOnlyFirstEventTimeIsRecorded() {
+        // Arrange
         final long fakeEventTimeEarlier = MARCH_18_2014_838PM_UTC;
-        final long fakeEventTimeLater
-                = fakeEventTimeEarlier + TimeUnit.DAYS.toMillis(1);
+        final long fakeEventTimeLater = fakeEventTimeEarlier + TimeUnit.DAYS.toMillis(1);
 
         assert fakeEventTimeEarlier < fakeEventTimeLater;
 
@@ -89,11 +89,10 @@ public class FirstTimeTrackerTest extends BaseTest {
         triggerEventAtTime(mockEvent, fakeEventTimeLater);
 
         // Assert
-
-        // Check that the earlier event time was saved, and the second event time ignored:
         final Long savedEventTime = fakeSettings.getEventValue(mockEvent, mockEventCheck);
 
-        assertEquals("The correct (earliest) time should have been recorded for this event",
+        assertEquals(
+                "The correct (earliest) time should have been recorded for this event",
                 Long.valueOf(fakeEventTimeEarlier), savedEventTime);
     }
 

--- a/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/FirstTimeTrackerTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/FirstTimeTrackerTest.java
@@ -20,7 +20,7 @@ import android.annotation.SuppressLint;
 import android.support.annotation.NonNull;
 
 import com.github.stkent.amplify.helpers.BaseTest;
-import com.github.stkent.amplify.helpers.MockSettings;
+import com.github.stkent.amplify.helpers.FakeSettings;
 import com.github.stkent.amplify.helpers.StubbedLogger;
 import com.github.stkent.amplify.tracking.ClockUtil;
 import com.github.stkent.amplify.tracking.interfaces.IApplicationInfoProvider;
@@ -38,7 +38,7 @@ public class FirstTimeTrackerTest extends BaseTest {
 
     private FirstTimeTracker firstTimeTracker;
 
-    private MockSettings<Long> mockSettings;
+    private FakeSettings<Long> fakeSettings;
 
     @Mock
     private IApplicationInfoProvider mockApplicationInfoProvider;
@@ -49,11 +49,10 @@ public class FirstTimeTrackerTest extends BaseTest {
 
     @Override
     public void localSetUp() {
-        mockSettings = new MockSettings<>();
+        fakeSettings = new FakeSettings<>();
 
         firstTimeTracker = new FirstTimeTracker(
-                new StubbedLogger(),
-                mockSettings,
+                new StubbedLogger(), fakeSettings,
                 mockApplicationInfoProvider);
 
         firstTimeTracker.trackEvent(mockEvent, mockEventCheck);
@@ -70,7 +69,7 @@ public class FirstTimeTrackerTest extends BaseTest {
         // Assert
 
         // Check that the correct event time was saved:
-        final Long savedEventTime = mockSettings.getEventValue(mockEvent, mockEventCheck);
+        final Long savedEventTime = fakeSettings.getEventValue(mockEvent, mockEventCheck);
 
         assertEquals("The correct time should have been recorded for this event", Long.valueOf(fakeEventTime), savedEventTime);
     }
@@ -92,7 +91,7 @@ public class FirstTimeTrackerTest extends BaseTest {
         // Assert
 
         // Check that the earlier event time was saved, and the second event time ignored:
-        final Long savedEventTime = mockSettings.getEventValue(mockEvent, mockEventCheck);
+        final Long savedEventTime = fakeSettings.getEventValue(mockEvent, mockEventCheck);
 
         assertEquals("The correct (earliest) time should have been recorded for this event",
                 Long.valueOf(fakeEventTimeEarlier), savedEventTime);

--- a/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/FirstTimeTrackerTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/FirstTimeTrackerTest.java
@@ -100,7 +100,7 @@ public class FirstTimeTrackerTest extends BaseTest {
 
     private void triggerEventAtTime(@NonNull final IEvent event, final long time) {
         ClockUtil.setFakeCurrentTimeMillis(time);
-        firstTimeTracker.eventTriggered(event);
+        firstTimeTracker.notifyEventTriggered(event);
     }
 
 }

--- a/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/LastTimeTrackerTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/LastTimeTrackerTest.java
@@ -21,7 +21,7 @@ import android.support.annotation.NonNull;
 
 import com.github.stkent.amplify.helpers.BaseTest;
 import com.github.stkent.amplify.helpers.FakeSettings;
-import com.github.stkent.amplify.helpers.StubbedLogger;
+import com.github.stkent.amplify.helpers.StubLogger;
 import com.github.stkent.amplify.tracking.ClockUtil;
 import com.github.stkent.amplify.tracking.interfaces.IApplicationInfoProvider;
 import com.github.stkent.amplify.tracking.interfaces.IEvent;
@@ -52,7 +52,7 @@ public class LastTimeTrackerTest extends BaseTest {
         fakeSettings = new FakeSettings<>();
 
         lastTimeTracker = new LastTimeTracker(
-                new StubbedLogger(), fakeSettings,
+                new StubLogger(), fakeSettings,
                 mockApplicationInfoProvider);
 
         lastTimeTracker.trackEvent(mockEvent, mockEventCheck);

--- a/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/LastTimeTrackerTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/LastTimeTrackerTest.java
@@ -100,7 +100,7 @@ public class LastTimeTrackerTest extends BaseTest {
 
     private void triggerEventAtTime(@NonNull final IEvent event, final long time) {
         ClockUtil.setFakeCurrentTimeMillis(time);
-        lastTimeTracker.eventTriggered(event);
+        lastTimeTracker.notifyEventTriggered(event);
     }
 
 }

--- a/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/LastTimeTrackerTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/LastTimeTrackerTest.java
@@ -52,7 +52,8 @@ public class LastTimeTrackerTest extends BaseTest {
         fakeSettings = new FakeSettings<>();
 
         lastTimeTracker = new LastTimeTracker(
-                new StubLogger(), fakeSettings,
+                new StubLogger(),
+                fakeSettings,
                 mockApplicationInfoProvider);
 
         lastTimeTracker.trackEvent(mockEvent, mockEventCheck);
@@ -67,20 +68,19 @@ public class LastTimeTrackerTest extends BaseTest {
         triggerEventAtTime(mockEvent, fakeEventTime);
 
         // Assert
-
-        // Check that the correct event time was saved:
         final Long savedEventTime = fakeSettings.getEventValue(mockEvent, mockEventCheck);
 
-        assertEquals("The correct time should have been recorded for this event", Long.valueOf(fakeEventTime), savedEventTime);
+        assertEquals(
+                "The correct time should have been recorded for this event",
+                Long.valueOf(fakeEventTime), savedEventTime);
     }
 
     @SuppressLint("Assert")
     @Test
     public void testThatSecondEventTimesIsRecorded() {
-        // Arrange Act
+        // Arrange
         final long fakeEventTimeEarlier = MARCH_18_2014_838PM_UTC;
-        final long fakeEventTimeLater
-                = fakeEventTimeEarlier + TimeUnit.DAYS.toMillis(1);
+        final long fakeEventTimeLater = fakeEventTimeEarlier + TimeUnit.DAYS.toMillis(1);
 
         assert fakeEventTimeEarlier < fakeEventTimeLater;
 
@@ -89,11 +89,10 @@ public class LastTimeTrackerTest extends BaseTest {
         triggerEventAtTime(mockEvent, fakeEventTimeLater);
 
         // Assert
-
-        // Check that the earlier event time was saved, and the second event time ignored:
         final Long savedEventTime = fakeSettings.getEventValue(mockEvent, mockEventCheck);
 
-        assertEquals("The correct (latest) time should have been recorded for this event",
+        assertEquals(
+                "The correct (latest) time should have been recorded for this event",
                 Long.valueOf(fakeEventTimeLater), savedEventTime);
     }
 

--- a/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/LastTimeTrackerTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/LastTimeTrackerTest.java
@@ -20,7 +20,7 @@ import android.annotation.SuppressLint;
 import android.support.annotation.NonNull;
 
 import com.github.stkent.amplify.helpers.BaseTest;
-import com.github.stkent.amplify.helpers.MockSettings;
+import com.github.stkent.amplify.helpers.FakeSettings;
 import com.github.stkent.amplify.helpers.StubbedLogger;
 import com.github.stkent.amplify.tracking.ClockUtil;
 import com.github.stkent.amplify.tracking.interfaces.IApplicationInfoProvider;
@@ -38,7 +38,7 @@ public class LastTimeTrackerTest extends BaseTest {
 
     private LastTimeTracker lastTimeTracker;
 
-    private MockSettings<Long> mockSettings;
+    private FakeSettings<Long> fakeSettings;
 
     @Mock
     private IApplicationInfoProvider mockApplicationInfoProvider;
@@ -49,11 +49,10 @@ public class LastTimeTrackerTest extends BaseTest {
 
     @Override
     public void localSetUp() {
-        mockSettings = new MockSettings<>();
+        fakeSettings = new FakeSettings<>();
 
         lastTimeTracker = new LastTimeTracker(
-                new StubbedLogger(),
-                mockSettings,
+                new StubbedLogger(), fakeSettings,
                 mockApplicationInfoProvider);
 
         lastTimeTracker.trackEvent(mockEvent, mockEventCheck);
@@ -70,7 +69,7 @@ public class LastTimeTrackerTest extends BaseTest {
         // Assert
 
         // Check that the correct event time was saved:
-        final Long savedEventTime = mockSettings.getEventValue(mockEvent, mockEventCheck);
+        final Long savedEventTime = fakeSettings.getEventValue(mockEvent, mockEventCheck);
 
         assertEquals("The correct time should have been recorded for this event", Long.valueOf(fakeEventTime), savedEventTime);
     }
@@ -92,7 +91,7 @@ public class LastTimeTrackerTest extends BaseTest {
         // Assert
 
         // Check that the earlier event time was saved, and the second event time ignored:
-        final Long savedEventTime = mockSettings.getEventValue(mockEvent, mockEventCheck);
+        final Long savedEventTime = fakeSettings.getEventValue(mockEvent, mockEventCheck);
 
         assertEquals("The correct (latest) time should have been recorded for this event",
                 Long.valueOf(fakeEventTimeLater), savedEventTime);

--- a/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/TotalCountTrackerTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/TotalCountTrackerTest.java
@@ -1,0 +1,56 @@
+package com.github.stkent.amplify.tracking.trackers;
+
+import android.annotation.SuppressLint;
+
+import com.github.stkent.amplify.helpers.BaseTest;
+import com.github.stkent.amplify.helpers.FakeSettings;
+import com.github.stkent.amplify.helpers.StubLogger;
+import com.github.stkent.amplify.tracking.interfaces.IApplicationInfoProvider;
+import com.github.stkent.amplify.tracking.interfaces.IEvent;
+import com.github.stkent.amplify.tracking.interfaces.IEventCheck;
+
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+
+public class TotalCountTrackerTest extends BaseTest {
+
+    @Mock
+    private IApplicationInfoProvider mockApplicationInfoProvider;
+    @Mock
+    private IEvent mockEvent;
+    @Mock
+    private IEventCheck<Integer> mockEventCheck;
+
+    @SuppressLint("Assert")
+    @Test
+    public void testThatCorrectNumberOfEventsIsRecorded() {
+        // Arrange
+        final FakeSettings<Integer> fakeSettings = new FakeSettings<>();
+
+        final TotalCountTracker totalCountTracker = new TotalCountTracker(
+                new StubLogger(),
+                fakeSettings,
+                mockApplicationInfoProvider);
+
+        totalCountTracker.trackEvent(mockEvent, mockEventCheck);
+
+        final Integer expectedEventCount = 7;
+        assert expectedEventCount > 0;
+
+        // Act
+        for (int i = 0; i < expectedEventCount; i++) {
+            totalCountTracker.notifyEventTriggered(mockEvent);
+        }
+
+        // Assert
+        final Integer actualEventCount = fakeSettings.getEventValue(mockEvent, mockEventCheck);
+
+        assertEquals(
+                "The correct number of events should have been recorded",
+                expectedEventCount,
+                actualEventCount);
+    }
+
+}

--- a/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/TotalCountTrackerTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/TotalCountTrackerTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2015 Stuart Kent
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.github.stkent.amplify.tracking.trackers;
 
 import android.annotation.SuppressLint;


### PR DESCRIPTION
Merge after #37 

A bunch of logic was being repeated in all the tracking classes. Just made the subclasses responsible for updating the existing value (they are now provided with the cached value), and handled all the persistence in the base EventTracker. Updated some method and param names to match also.