### PR TITLE
Add static access to logger instance

### DIFF
--- a/amplify/src/main/java/com/github/stkent/amplify/AmplifyLogger.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/AmplifyLogger.java
@@ -1,0 +1,25 @@
+package com.github.stkent.amplify;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
+
+public class AmplifyLogger {
+
+    @NonNull
+    private static ILogger logger = new Logger();
+
+    @NonNull
+    public static ILogger getLogger() {
+        return logger;
+    }
+
+    public static void setLogLevel(@NonNull final Logger.LogLevel logLevel) {
+        logger.setLogLevel(logLevel);
+    }
+
+    @VisibleForTesting
+    public static void setLogger(@NonNull final ILogger logger) {
+        AmplifyLogger.logger = logger;
+    }
+
+}

--- a/amplify/src/main/java/com/github/stkent/amplify/AmplifyLogger.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/AmplifyLogger.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2015 Stuart Kent
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.github.stkent.amplify;
 
 import android.support.annotation.NonNull;

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/Settings.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/Settings.java
@@ -21,7 +21,7 @@ import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.github.stkent.amplify.ILogger;
+import com.github.stkent.amplify.AmplifyLogger;
 import com.github.stkent.amplify.tracking.interfaces.ISettings;
 
 import java.util.Map;
@@ -31,10 +31,8 @@ public class Settings<T> implements ISettings<T> {
     private static final String SHARED_PREFERENCES_NAME = "AMPLIFY_SHARED_PREFERENCES_NAME";
 
     private final SharedPreferences sharedPreferences;
-    private final ILogger logger;
 
-    public Settings(Context applicationContext, ILogger logger) {
-        this.logger = logger;
+    public Settings(Context applicationContext) {
         this.sharedPreferences = applicationContext
                 .getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
     }
@@ -71,7 +69,7 @@ public class Settings<T> implements ISettings<T> {
             }
         }
 
-        logger.e("No event value for " + trackingKey);
+        AmplifyLogger.getLogger().e("No event value for " + trackingKey);
 
         return null;
     }

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/interfaces/IAmplifyStateTracker.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/interfaces/IAmplifyStateTracker.java
@@ -18,14 +18,11 @@ package com.github.stkent.amplify.tracking.interfaces;
 
 import android.support.annotation.NonNull;
 
-import com.github.stkent.amplify.Logger;
 import com.github.stkent.amplify.views.AmplifyView;
 
 public interface IAmplifyStateTracker {
 
     IAmplifyStateTracker configureWithDefaults();
-
-    IAmplifyStateTracker setLogLevel(@NonNull final Logger.LogLevel logLevel);
 
     IAmplifyStateTracker setAlwaysShow(final boolean alwaysShow);
 

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/EventTracker.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/EventTracker.java
@@ -18,7 +18,7 @@ package com.github.stkent.amplify.tracking.trackers;
 
 import android.support.annotation.NonNull;
 
-import com.github.stkent.amplify.ILogger;
+import com.github.stkent.amplify.AmplifyLogger;
 import com.github.stkent.amplify.tracking.interfaces.IApplicationInfoProvider;
 import com.github.stkent.amplify.tracking.interfaces.IEvent;
 import com.github.stkent.amplify.tracking.interfaces.IEventCheck;
@@ -33,7 +33,6 @@ public abstract class EventTracker<T> {
 
     private static final String AMPLIFY_TRACKING_KEY_PREFIX = "AMPLIFY_";
 
-    private final ILogger logger;
     private final IApplicationInfoProvider applicationInfoProvider;
     private final ISettings<T> settings;
     private final ConcurrentHashMap<IEvent, List<IEventCheck<T>>> internalMap;
@@ -52,10 +51,8 @@ public abstract class EventTracker<T> {
     protected abstract T getUpdatedTrackingValue(@NonNull final T cachedEventValue);
 
     public EventTracker(
-            @NonNull final ILogger logger,
             @NonNull final ISettings<T> settings,
             @NonNull final IApplicationInfoProvider applicationInfoProvider) {
-        this.logger = logger;
         this.settings = settings;
         this.applicationInfoProvider = applicationInfoProvider;
         this.internalMap = new ConcurrentHashMap<>();
@@ -68,7 +65,7 @@ public abstract class EventTracker<T> {
 
         internalMap.get(event).add(eventCheck);
 
-        logger.d(internalMap.get(event).toString());
+        AmplifyLogger.getLogger().d(internalMap.get(event).toString());
     }
 
     public void notifyEventTriggered(@NonNull final IEvent event) {
@@ -78,7 +75,7 @@ public abstract class EventTracker<T> {
             final T updatedTrackingValue = getUpdatedTrackingValue(cachedTrackingValue);
 
             if (!updatedTrackingValue.equals(cachedTrackingValue)) {
-                logger.d(IEventCheck.class.getSimpleName()
+                AmplifyLogger.getLogger().d(IEventCheck.class.getSimpleName()
                         + " updating event value from: "
                         + cachedTrackingValue
                         + " to "
@@ -97,10 +94,10 @@ public abstract class EventTracker<T> {
             for (final IEventCheck<T> eventCheck : eventCheckSet.getValue()) {
                 final T cachedEventValue = getCachedTrackingValue(event);
 
-                logger.d(getTrackingKey(event) + ": " + eventCheck.getStatusString(cachedEventValue, applicationInfoProvider));
+                AmplifyLogger.getLogger().d(getTrackingKey(event) + ": " + eventCheck.getStatusString(cachedEventValue, applicationInfoProvider));
 
                 if (eventCheck.shouldBlockFeedbackPrompt(cachedEventValue, applicationInfoProvider)) {
-                    logger.d("Blocking feedback for event: " + event + " because of check: " + eventCheck);
+                    AmplifyLogger.getLogger().d("Blocking feedback for event: " + event + " because of check: " + eventCheck);
                     return false;
                 }
             }
@@ -111,10 +108,6 @@ public abstract class EventTracker<T> {
 
     public boolean containsEvent(@NonNull final IEvent event) {
         return internalMap.containsKey(event);
-    }
-
-    protected ILogger getLogger() {
-        return logger;
     }
 
     protected IApplicationInfoProvider getApplicationInfoProvider() {

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/FirstTimeTracker.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/FirstTimeTracker.java
@@ -20,7 +20,6 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
-import com.github.stkent.amplify.ILogger;
 import com.github.stkent.amplify.tracking.ApplicationInfoProvider;
 import com.github.stkent.amplify.tracking.ClockUtil;
 import com.github.stkent.amplify.tracking.Settings;
@@ -29,16 +28,15 @@ import com.github.stkent.amplify.tracking.interfaces.ISettings;
 
 public class FirstTimeTracker extends EventTracker<Long> {
 
-    public FirstTimeTracker(@NonNull final ILogger logger, @NonNull final Context applicationContext) {
-        this(logger, new Settings<Long>(applicationContext, logger), new ApplicationInfoProvider(applicationContext));
+    public FirstTimeTracker(@NonNull final Context applicationContext) {
+        this(new Settings<Long>(applicationContext), new ApplicationInfoProvider(applicationContext));
     }
 
     @VisibleForTesting
     protected FirstTimeTracker(
-            @NonNull final ILogger logger,
             @NonNull final ISettings<Long> settings,
             @NonNull final IApplicationInfoProvider applicationInfoProvider) {
-        super(logger, settings, applicationInfoProvider);
+        super(settings, applicationInfoProvider);
     }
 
     @NonNull

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/LastTimeTracker.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/LastTimeTracker.java
@@ -20,7 +20,6 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
-import com.github.stkent.amplify.ILogger;
 import com.github.stkent.amplify.tracking.ApplicationInfoProvider;
 import com.github.stkent.amplify.tracking.ClockUtil;
 import com.github.stkent.amplify.tracking.Settings;
@@ -29,16 +28,15 @@ import com.github.stkent.amplify.tracking.interfaces.ISettings;
 
 public class LastTimeTracker extends EventTracker<Long> {
 
-    public LastTimeTracker(@NonNull final ILogger logger, @NonNull final Context applicationContext) {
-        this(logger, new Settings<Long>(applicationContext, logger), new ApplicationInfoProvider(applicationContext));
+    public LastTimeTracker(@NonNull final Context applicationContext) {
+        this(new Settings<Long>(applicationContext), new ApplicationInfoProvider(applicationContext));
     }
 
     @VisibleForTesting
     protected LastTimeTracker(
-            @NonNull final ILogger logger,
             @NonNull final ISettings<Long> settings,
             @NonNull final IApplicationInfoProvider applicationInfoProvider) {
-        super(logger, settings, applicationInfoProvider);
+        super(settings, applicationInfoProvider);
     }
 
     @NonNull

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/LastVersionTracker.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/LastVersionTracker.java
@@ -21,7 +21,7 @@ import android.content.pm.PackageManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
-import com.github.stkent.amplify.ILogger;
+import com.github.stkent.amplify.AmplifyLogger;
 import com.github.stkent.amplify.tracking.ApplicationInfoProvider;
 import com.github.stkent.amplify.tracking.Settings;
 import com.github.stkent.amplify.tracking.interfaces.IApplicationInfoProvider;
@@ -29,16 +29,15 @@ import com.github.stkent.amplify.tracking.interfaces.ISettings;
 
 public class LastVersionTracker extends EventTracker<String> {
 
-    public LastVersionTracker(@NonNull final ILogger logger, @NonNull final Context applicationContext) {
-        this(logger, new Settings<String>(applicationContext, logger), new ApplicationInfoProvider(applicationContext));
+    public LastVersionTracker(@NonNull final Context applicationContext) {
+        this(new Settings<String>(applicationContext), new ApplicationInfoProvider(applicationContext));
     }
 
     @VisibleForTesting
     protected LastVersionTracker(
-            @NonNull final ILogger logger,
             @NonNull final ISettings<String> settings,
             @NonNull final IApplicationInfoProvider applicationInfoProvider) {
-        super(logger, settings, applicationInfoProvider);
+        super(settings, applicationInfoProvider);
     }
 
     @NonNull
@@ -59,7 +58,7 @@ public class LastVersionTracker extends EventTracker<String> {
         try {
             return getApplicationInfoProvider().getVersionName();
         } catch (final PackageManager.NameNotFoundException e) {
-            getLogger().d("Could not read current app version name.");
+            AmplifyLogger.getLogger().d("Could not read current app version name.");
             return cachedTrackingValue;
         }
     }

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/TotalCountTracker.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/trackers/TotalCountTracker.java
@@ -20,7 +20,6 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
-import com.github.stkent.amplify.ILogger;
 import com.github.stkent.amplify.tracking.ApplicationInfoProvider;
 import com.github.stkent.amplify.tracking.Settings;
 import com.github.stkent.amplify.tracking.interfaces.IApplicationInfoProvider;
@@ -28,16 +27,15 @@ import com.github.stkent.amplify.tracking.interfaces.ISettings;
 
 public class TotalCountTracker extends EventTracker<Integer> {
 
-    public TotalCountTracker(@NonNull final ILogger logger, @NonNull final Context applicationContext) {
-        this(logger, new Settings<Integer>(applicationContext, logger), new ApplicationInfoProvider(applicationContext));
+    public TotalCountTracker(@NonNull final Context applicationContext) {
+        this(new Settings<Integer>(applicationContext), new ApplicationInfoProvider(applicationContext));
     }
 
     @VisibleForTesting
     protected TotalCountTracker(
-            @NonNull final ILogger logger,
             @NonNull final ISettings<Integer> settings,
             @NonNull final IApplicationInfoProvider applicationInfoProvider) {
-        super(logger, settings, applicationInfoProvider);
+        super(settings, applicationInfoProvider);
     }
 
     @NonNull

--- a/amplify/src/test/java/com/github/stkent/amplify/helpers/CustomTestRunner.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/helpers/CustomTestRunner.java
@@ -1,0 +1,27 @@
+package com.github.stkent.amplify.helpers;
+
+import com.github.stkent.amplify.AmplifyLogger;
+
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.InitializationError;
+
+public class CustomTestRunner extends BlockJUnit4ClassRunner {
+
+    private static boolean initialized = false;
+
+    public CustomTestRunner(Class<?> klass) throws InitializationError {
+        super(klass);
+
+        synchronized (CustomTestRunner.class) {
+            if (!initialized) {
+                globalOneTimeSetUp();
+            }
+        }
+    }
+
+    private static void globalOneTimeSetUp() {
+        AmplifyLogger.setLogger(new StubLogger());
+        initialized = true;
+    }
+
+}

--- a/amplify/src/test/java/com/github/stkent/amplify/helpers/CustomTestRunner.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/helpers/CustomTestRunner.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2015 Stuart Kent
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.github.stkent.amplify.helpers;
 
 import com.github.stkent.amplify.AmplifyLogger;

--- a/amplify/src/test/java/com/github/stkent/amplify/helpers/StubLogger.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/helpers/StubLogger.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2015 Stuart Kent
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.github.stkent.amplify.helpers;
 
 import android.support.annotation.NonNull;

--- a/amplify/src/test/java/com/github/stkent/amplify/helpers/StubLogger.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/helpers/StubLogger.java
@@ -1,0 +1,25 @@
+package com.github.stkent.amplify.helpers;
+
+import android.support.annotation.NonNull;
+
+import com.github.stkent.amplify.ILogger;
+import com.github.stkent.amplify.Logger;
+
+public class StubLogger implements ILogger {
+
+    @Override
+    public void setLogLevel(@NonNull final Logger.LogLevel logLevel) {
+        // no-op
+    }
+
+    @Override
+    public void d(@NonNull final String message) {
+        // no-op
+    }
+
+    @Override
+    public void e(@NonNull final String message) {
+        // no-op
+    }
+
+}

--- a/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/FirstTimeTrackerTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/FirstTimeTrackerTest.java
@@ -19,7 +19,6 @@ package com.github.stkent.amplify.tracking.trackers;
 import android.annotation.SuppressLint;
 import android.support.annotation.NonNull;
 
-import com.github.stkent.amplify.ILogger;
 import com.github.stkent.amplify.helpers.BaseTest;
 import com.github.stkent.amplify.helpers.FakeSettings;
 import com.github.stkent.amplify.tracking.ClockUtil;
@@ -43,8 +42,6 @@ public class FirstTimeTrackerTest extends BaseTest {
     private FakeSettings<Long> fakeSettings;
 
     @Mock
-    private ILogger mockLogger;
-    @Mock
     private IApplicationInfoProvider mockApplicationInfoProvider;
     @Mock
     private IEvent mockEvent;
@@ -56,7 +53,6 @@ public class FirstTimeTrackerTest extends BaseTest {
         fakeSettings = new FakeSettings<>();
 
         firstTimeTracker = new FirstTimeTracker(
-                mockLogger,
                 fakeSettings,
                 mockApplicationInfoProvider);
 

--- a/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/LastTimeTrackerTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/LastTimeTrackerTest.java
@@ -19,7 +19,6 @@ package com.github.stkent.amplify.tracking.trackers;
 import android.annotation.SuppressLint;
 import android.support.annotation.NonNull;
 
-import com.github.stkent.amplify.ILogger;
 import com.github.stkent.amplify.helpers.BaseTest;
 import com.github.stkent.amplify.helpers.FakeSettings;
 import com.github.stkent.amplify.tracking.ClockUtil;
@@ -43,8 +42,6 @@ public class LastTimeTrackerTest extends BaseTest {
     private FakeSettings<Long> fakeSettings;
 
     @Mock
-    private ILogger mockLogger;
-    @Mock
     private IApplicationInfoProvider mockApplicationInfoProvider;
     @Mock
     private IEvent mockEvent;
@@ -56,7 +53,6 @@ public class LastTimeTrackerTest extends BaseTest {
         fakeSettings = new FakeSettings<>();
 
         lastTimeTracker = new LastTimeTracker(
-                mockLogger,
                 fakeSettings,
                 mockApplicationInfoProvider);
 

--- a/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/LastVersionTrackerTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/LastVersionTrackerTest.java
@@ -20,7 +20,6 @@ import android.annotation.SuppressLint;
 import android.content.pm.PackageManager;
 import android.support.annotation.NonNull;
 
-import com.github.stkent.amplify.ILogger;
 import com.github.stkent.amplify.helpers.BaseTest;
 import com.github.stkent.amplify.helpers.FakeSettings;
 import com.github.stkent.amplify.tracking.interfaces.IApplicationInfoProvider;
@@ -41,8 +40,6 @@ public class LastVersionTrackerTest extends BaseTest {
     private FakeSettings<String> fakeSettings;
 
     @Mock
-    private ILogger mockLogger;
-    @Mock
     private IApplicationInfoProvider mockApplicationInfoProvider;
     @Mock
     private IEvent mockEvent;
@@ -54,7 +51,6 @@ public class LastVersionTrackerTest extends BaseTest {
         fakeSettings = new FakeSettings<>();
 
         lastVersionTracker = new LastVersionTracker(
-                mockLogger,
                 fakeSettings,
                 mockApplicationInfoProvider);
 

--- a/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/TotalCountTrackerTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/tracking/trackers/TotalCountTrackerTest.java
@@ -19,7 +19,6 @@ package com.github.stkent.amplify.tracking.trackers;
 import android.annotation.SuppressLint;
 import android.support.annotation.NonNull;
 
-import com.github.stkent.amplify.ILogger;
 import com.github.stkent.amplify.helpers.BaseTest;
 import com.github.stkent.amplify.helpers.FakeSettings;
 import com.github.stkent.amplify.tracking.interfaces.IApplicationInfoProvider;
@@ -40,8 +39,6 @@ public class TotalCountTrackerTest extends BaseTest {
     private FakeSettings<Integer> fakeSettings;
 
     @Mock
-    private ILogger mockLogger;
-    @Mock
     private IApplicationInfoProvider mockApplicationInfoProvider;
     @Mock
     private IEvent mockEvent;
@@ -53,7 +50,6 @@ public class TotalCountTrackerTest extends BaseTest {
         fakeSettings = new FakeSettings<>();
 
         totalCountTracker = new TotalCountTracker(
-                mockLogger,
                 fakeSettings,
                 mockApplicationInfoProvider);
 


### PR DESCRIPTION
Questions:

Is it weird that you need to configure the logger using AmplifyLogger separately from configuring the tracker instance? Should we use the same static get() method for each to be consistent? Or should we move all configuration to a top-level `Amplify` class and hide the AmplifyStateTracker from the public API?