### PR TITLE
Minimum count rule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ android:
 branches:
   only:
     - master
-    # Match semvar branch names like 1.0.0, 1.0.0-rc.2, etc.:
+    # Match semver branch names like 1.0.0, 1.0.0-rc.2, etc.:
     - /^\d+\.\d+\.\d+(?:-rc\.\d+)?$/
 
 script: ./travis-build.sh

--- a/README.md
+++ b/README.md
@@ -212,8 +212,9 @@ To apply rules based on these events, use the configuration methods `addTotalEve
 _amplify_ is packaged with the following event-based rules:
 
 - `CooldownDaysRule`: checks whether enough time has elapsed since the last occurrence of this event.
-- `MaximumCountRule`: checks whether this event has occurred enough times.
-- `VersionChangedRule`: checks whether this event has occurred for the current version of the embedding application.
+- `MaximumCountRule`: checks whether this event has occurred fewer than N times, for some number N.
+- `MinimumCountRule`: checks whether this event has occurred at least N times, for some number N.
+- `VersionChangedRule`: checks whether this event has already occurred for the current version of the embedding application.
 - `WarmupDaysRule`: checks whether enough time has elapsed since the first occurrence of this event.
 
 An example configuration that leverage these rules is below:
@@ -285,7 +286,7 @@ Provided by the `DefaultLayoutPromptView` class. The basic layouts of the questi
     app:prompt_view_negative_button_border_color="@color/custom_negative_button_border_color" />
 ```
 
-All attributes are optional. The most important are `prompt_view_foreground_color` and `prompt_view_background_color`. All other attributes default to one of these two colors, so most use-cases can probably be supported by setting one or both of these attributes only.
+All attributes are optional. The most important are `prompt_view_foreground_color` and `prompt_view_background_color`. All other color attributes default to one of these two colors, so most use-cases can probably be supported by setting one or both of these attributes only.
 
 It is also possible to configure this layout in code. To do so, users apply a `BasePromptViewConfig` and/or a `DefaultLayoutPromptViewConfig` to the view. Each configuration type can be constructed using a builder, which allows only the desired attributes to be overridden. Below shows an example in which every possible attribute is configured this way:
 

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/rules/CooldownDaysRule.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/rules/CooldownDaysRule.java
@@ -28,6 +28,11 @@ public final class CooldownDaysRule implements IEventBasedRule<Long> {
     private final long cooldownPeriodDays;
 
     public CooldownDaysRule(final long cooldownPeriodDays) {
+        if (cooldownPeriodDays <= 0) {
+            throw new IllegalStateException(
+                    "Cooldown days rule must be configured with a positive cooldown period");
+        }
+
         this.cooldownPeriodDays = cooldownPeriodDays;
     }
 

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/rules/MaximumCountRule.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/rules/MaximumCountRule.java
@@ -25,6 +25,11 @@ public final class MaximumCountRule implements IEventBasedRule<Integer> {
     private final int maximumCount;
 
     public MaximumCountRule(final int maximumCount) {
+        if (maximumCount <= 0) {
+            throw new IllegalStateException(
+                    "Maximum count rule must be configured with a positive threshold");
+        }
+
         this.maximumCount = maximumCount;
     }
 

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/rules/MinimumCountRule.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/rules/MinimumCountRule.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2015 Stuart Kent
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.github.stkent.amplify.tracking.rules;
+
+import android.support.annotation.NonNull;
+
+import com.github.stkent.amplify.tracking.interfaces.IEventBasedRule;
+
+public final class MinimumCountRule implements IEventBasedRule<Integer> {
+
+    private final int minimumCount;
+
+    public MinimumCountRule(final int minimumCount) {
+        if (minimumCount <= 0) {
+            throw new IllegalStateException(
+                    "Minimum count rule must be configured with a positive threshold");
+        }
+
+        this.minimumCount = minimumCount;
+    }
+
+    @Override
+    public boolean shouldAllowFeedbackPromptByDefault() {
+        return false;
+    }
+
+    @Override
+    public boolean shouldAllowFeedbackPrompt(@NonNull final Integer cachedEventValue) {
+        return cachedEventValue >= minimumCount;
+    }
+
+    @NonNull
+    @Override
+    public String getDescription() {
+        return "MinimumCountRule with minimum required count of " + minimumCount;
+    }
+
+}

--- a/amplify/src/main/java/com/github/stkent/amplify/tracking/rules/WarmupDaysRule.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/tracking/rules/WarmupDaysRule.java
@@ -28,6 +28,11 @@ public class WarmupDaysRule implements IEventBasedRule<Long> {
     private final long warmupPeriodDays;
 
     public WarmupDaysRule(final long warmupPeriodDays) {
+        if (warmupPeriodDays <= 0) {
+            throw new IllegalStateException(
+                    "Warmup days rule must be configured with a positive warmup period");
+        }
+
         this.warmupPeriodDays = warmupPeriodDays;
     }
 

--- a/amplify/src/test/java/com/github/stkent/amplify/tracking/rules/MaximumCountRuleTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/tracking/rules/MaximumCountRuleTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public class MaximumCountRuleTest extends BaseTest {
 
     @SuppressLint("Assert")
@@ -44,6 +45,26 @@ public class MaximumCountRuleTest extends BaseTest {
         // Assert
         assertTrue(
                 "Feedback prompt should be allowed if the associated event has never occurred.",
+                ruleShouldAllowFeedbackPrompt);
+    }
+
+    @SuppressLint("Assert")
+    @SuppressWarnings({"ConstantConditions", "UnnecessaryLocalVariable"})
+    @Test
+    public void testThatRuleBlocksPromptAtCountThreshold() {
+        // Arrange
+        final int maximumEventCount = 7;
+        final int currentEventCount = maximumEventCount;
+
+        final MaximumCountRule maximumCountRule = new MaximumCountRule(maximumEventCount);
+
+        // Act
+        final boolean ruleShouldAllowFeedbackPrompt
+                = maximumCountRule.shouldAllowFeedbackPrompt(currentEventCount);
+
+        // Assert
+        assertFalse(
+                "Feedback prompt should be blocked at the count threshold.",
                 ruleShouldAllowFeedbackPrompt);
     }
 

--- a/amplify/src/test/java/com/github/stkent/amplify/tracking/rules/MinimumCountRuleTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/tracking/rules/MinimumCountRuleTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2015 Stuart Kent
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.github.stkent.amplify.tracking.rules;
+
+import android.annotation.SuppressLint;
+
+import com.github.stkent.amplify.helpers.BaseTest;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MinimumCountRuleTest extends BaseTest {
+
+    @SuppressLint("Assert")
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    public void testThatRuleBlocksPromptIfEventHasNeverOccurred() {
+        // Arrange
+        final int anyPositiveInteger = 1;
+        assert anyPositiveInteger > 0;
+
+        final MinimumCountRule minimumCountRule = new MinimumCountRule(anyPositiveInteger);
+
+        // Act
+        final boolean ruleShouldAllowFeedbackPrompt
+                = minimumCountRule.shouldAllowFeedbackPromptByDefault();
+
+        // Assert
+        assertFalse(
+                "Feedback prompt should be blocked if the associated event has never occurred.",
+                ruleShouldAllowFeedbackPrompt);
+    }
+
+    @SuppressLint("Assert")
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    public void testThatRuleAllowsPromptIfCountThresholdHasBeenExceeded() {
+        // Arrange
+        final int minimumEventCount = 7;
+        final int currentEventCount = 9;
+        assert currentEventCount > minimumEventCount;
+
+        final MinimumCountRule minimumCountRule = new MinimumCountRule(minimumEventCount);
+
+        // Act
+        final boolean ruleShouldAllowFeedbackPrompt
+                = minimumCountRule.shouldAllowFeedbackPrompt(currentEventCount);
+
+        // Assert
+        assertTrue(
+                "Feedback prompt should be blocked if the count threshold has been exceeded",
+                ruleShouldAllowFeedbackPrompt);
+    }
+
+    @SuppressLint("Assert")
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    public void testThatRuleBlocksPromptIfCountThresholdHasNotBeenExceeded() {
+        // Arrange
+        final int minimumEventCount = 7;
+        final int currentEventCount = 2;
+        assert currentEventCount < minimumEventCount;
+
+        final MinimumCountRule minimumCountRule = new MinimumCountRule(minimumEventCount);
+
+        // Act
+        final boolean ruleShouldAllowFeedbackPrompt
+                = minimumCountRule.shouldAllowFeedbackPrompt(currentEventCount);
+
+        // Assert
+        assertFalse(
+                "Feedback prompt should be blocked if the count threshold has not been exceeded",
+                ruleShouldAllowFeedbackPrompt);
+    }
+
+}

--- a/amplify/src/test/java/com/github/stkent/amplify/tracking/rules/MinimumCountRuleTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/tracking/rules/MinimumCountRuleTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public class MinimumCountRuleTest extends BaseTest {
 
     @SuppressLint("Assert")
@@ -48,6 +49,26 @@ public class MinimumCountRuleTest extends BaseTest {
     }
 
     @SuppressLint("Assert")
+    @SuppressWarnings({"ConstantConditions", "UnnecessaryLocalVariable"})
+    @Test
+    public void testThatRuleAllowsPromptAtCountThreshold() {
+        // Arrange
+        final int minimumEventCount = 7;
+        final int currentEventCount = minimumEventCount;
+
+        final MinimumCountRule minimumCountRule = new MinimumCountRule(minimumEventCount);
+
+        // Act
+        final boolean ruleShouldAllowFeedbackPrompt
+                = minimumCountRule.shouldAllowFeedbackPrompt(currentEventCount);
+
+        // Assert
+        assertTrue(
+                "Feedback prompt should be allowed at the count threshold.",
+                ruleShouldAllowFeedbackPrompt);
+    }
+
+    @SuppressLint("Assert")
     @SuppressWarnings("ConstantConditions")
     @Test
     public void testThatRuleAllowsPromptIfCountThresholdHasBeenExceeded() {
@@ -64,7 +85,7 @@ public class MinimumCountRuleTest extends BaseTest {
 
         // Assert
         assertTrue(
-                "Feedback prompt should be blocked if the count threshold has been exceeded",
+                "Feedback prompt should be allowed if the count threshold has been exceeded",
                 ruleShouldAllowFeedbackPrompt);
     }
 


### PR DESCRIPTION
#### Issue Link
<!-- (Required) Link to GitHub issue/JIRA card/Trello card -->

Closes #124 

#### Goals
<!-- (Required) Summarize the goals of this PR -->

Add a new default event-based rule that will allow the feedback prompt to be shown only if the associated event has occurred _at least_ the given number of times.

#### Testing Notes
<!-- (Required) List steps to test this PR manually -->

New unit tests added to cover this rule; rule is not applied by default so there should be no changes in default library behavior.