### PR TITLE
Fixed BadParcelException

### DIFF
--- a/amplify/src/main/java/com/github/stkent/amplify/prompt/BasePromptView.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/prompt/BasePromptView.java
@@ -1,13 +1,13 @@
 /**
  * Copyright 2015 Stuart Kent
- *
+ * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.
- *
+ * <p/>
  * You may obtain a copy of the License at
- *
+ * <p/>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -124,7 +124,7 @@ abstract class BasePromptView<T extends View & IQuestionView, U extends View & I
     @Override
     protected void onRestoreInstanceState(@NonNull final Parcelable state) {
         final SavedState savedState = (SavedState) state;
-        super.onRestoreInstanceState(savedState.getSuperState());
+        super.onRestoreInstanceState(savedState.superState);
         thanksDisplayTimeExpired = savedState.thanksDisplayTimeExpired;
     }
 
@@ -307,20 +307,23 @@ abstract class BasePromptView<T extends View & IQuestionView, U extends View & I
         setVisibility(GONE);
     }
 
-    private static class SavedState extends BaseSavedState {
+    protected static class SavedState extends BaseSavedState {
 
         private static final int TRUTHY_INT = 1;
         private static final int FALSEY_INT = 0;
 
+        protected final Parcelable superState;
         private Bundle promptPresenterState;
         private boolean thanksDisplayTimeExpired;
 
         protected SavedState(final Parcelable superState) {
-            super(superState);
+            super(EMPTY_STATE);
+            this.superState = superState;
         }
 
         protected SavedState(final Parcel in) {
             super(in);
+            this.superState = in.readParcelable(SavedState.class.getClassLoader());
             this.promptPresenterState = in.readBundle(getClass().getClassLoader());
             this.thanksDisplayTimeExpired = in.readInt() == TRUTHY_INT;
         }
@@ -328,6 +331,7 @@ abstract class BasePromptView<T extends View & IQuestionView, U extends View & I
         @Override
         public void writeToParcel(final Parcel out, final int flags) {
             super.writeToParcel(out, flags);
+            out.writeParcelable(superState, flags);
             out.writeBundle(this.promptPresenterState);
             out.writeInt(this.thanksDisplayTimeExpired ? TRUTHY_INT : FALSEY_INT);
         }

--- a/amplify/src/main/java/com/github/stkent/amplify/prompt/BasePromptView.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/prompt/BasePromptView.java
@@ -1,13 +1,13 @@
 /**
  * Copyright 2015 Stuart Kent
- * <p/>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.
- * <p/>
+ *
  * You may obtain a copy of the License at
- * <p/>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the

--- a/amplify/src/main/java/com/github/stkent/amplify/prompt/CustomLayoutPromptView.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/prompt/CustomLayoutPromptView.java
@@ -1,13 +1,13 @@
 /**
  * Copyright 2015 Stuart Kent
- *
+ * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.
- *
+ * <p/>
  * You may obtain a copy of the License at
- *
+ * <p/>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -74,7 +74,7 @@ public final class CustomLayoutPromptView
     @Override
     protected void onRestoreInstanceState(@NonNull final Parcelable state) {
         final SavedState savedState = (SavedState) state;
-        final Parcelable superSavedState = savedState.getSuperState();
+        final Parcelable superSavedState = savedState.superState;
 
         super.onRestoreInstanceState(superSavedState);
 
@@ -118,7 +118,7 @@ public final class CustomLayoutPromptView
         typedArray.recycle();
     }
 
-    private static class SavedState extends BaseSavedState {
+    private static class SavedState extends BasePromptView.SavedState {
 
         private CustomLayoutPromptViewConfig config;
 

--- a/amplify/src/main/java/com/github/stkent/amplify/prompt/CustomLayoutPromptView.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/prompt/CustomLayoutPromptView.java
@@ -1,13 +1,13 @@
 /**
  * Copyright 2015 Stuart Kent
- * <p/>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.
- * <p/>
+ *
  * You may obtain a copy of the License at
- * <p/>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the

--- a/amplify/src/main/java/com/github/stkent/amplify/prompt/DefaultLayoutPromptView.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/prompt/DefaultLayoutPromptView.java
@@ -1,13 +1,13 @@
 /**
  * Copyright 2015 Stuart Kent
- *
+ * <p/>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.
- *
+ * <p/>
  * You may obtain a copy of the License at
- *
+ * <p/>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -73,9 +73,9 @@ public final class DefaultLayoutPromptView
     @Override
     protected void onRestoreInstanceState(@NonNull final Parcelable state) {
         final SavedState savedState = (SavedState) state;
-        final Parcelable superSavedState = savedState.getSuperState();
+        final Parcelable superSavedState = savedState.superState;
 
-        super.onRestoreInstanceState(savedState.getSuperState());
+        super.onRestoreInstanceState(superSavedState);
 
         applyConfig(savedState.config);
 
@@ -114,7 +114,7 @@ public final class DefaultLayoutPromptView
         typedArray.recycle();
     }
 
-    private static class SavedState extends BaseSavedState {
+    private static class SavedState extends BasePromptView.SavedState {
 
         private DefaultLayoutPromptViewConfig config;
 

--- a/amplify/src/main/java/com/github/stkent/amplify/prompt/DefaultLayoutPromptView.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/prompt/DefaultLayoutPromptView.java
@@ -1,13 +1,13 @@
 /**
  * Copyright 2015 Stuart Kent
- * <p/>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.
- * <p/>
+ *
  * You may obtain a copy of the License at
- * <p/>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the


### PR DESCRIPTION
#### Issue Link
<!-- (Required) Link to GitHub issue/JIRA card/Trello card -->
https://github.com/stkent/amplify/issues/146


#### Goals
<!-- (Required) Summarize the goals of this PR -->
Fix crash when restoring state of a prompt view.


#### Implementation Notes
<!-- (Optional) Highlight any new utility code -->
<!-- (Optional) Highlight tricky decisions and explain your choices  -->
I've updated the SavedState in BasePromptView to send an EMPTY_STATE up to super which removed any Amplify classes being passed up to AbsSavedState. The issue is caused by AbsSavedState using a null class loader which causes a crash when trying to unmarshal Amplify classes.
 

#### Testing Notes
<!-- (Required) List steps to test this PR manually -->
To test this you can open the example application and then click the home button. After home screening the app you must cause it to be removed from memory which will save the state of the views. You can do this by going to the AndroidMonitor tab in Android Studio and clicking the red X (Terminate Application) on the left side of the screen. Then just open the app on your device and it will attempt to restore the view state. With the current version this will crash.

**Note:** One thing to check in this PR is that it still saves all the state it should.


