### PR TITLE
Fix crash when restoring prompt view state

### DIFF
--- a/amplify/src/main/java/com/github/stkent/amplify/prompt/CustomLayoutPromptView.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/prompt/CustomLayoutPromptView.java
@@ -18,7 +18,7 @@ package com.github.stkent.amplify.prompt;
 
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.os.Parcel;
+import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -30,6 +30,9 @@ import com.github.stkent.amplify.prompt.interfaces.IPromptView;
 public final class CustomLayoutPromptView
         extends BasePromptView<CustomLayoutQuestionView, CustomLayoutThanksView>
         implements IPromptView {
+
+    private static final String CUSTOM_LAYOUT_PROMPT_VIEW_CONFIG_KEY
+            = "CUSTOM_LAYOUT_PROMPT_VIEW_CONFIG_KEY";
 
     // NonNull
     private CustomLayoutPromptViewConfig config;
@@ -66,21 +69,30 @@ public final class CustomLayoutPromptView
     @Override
     protected Parcelable onSaveInstanceState() {
         final Parcelable superState = super.onSaveInstanceState();
-        final SavedState savedState = new SavedState(superState);
-        savedState.config = config;
-        return savedState;
+
+        final Bundle result = new Bundle();
+        result.putParcelable(SUPER_STATE_KEY, superState);
+        result.putParcelable(CUSTOM_LAYOUT_PROMPT_VIEW_CONFIG_KEY, config);
+        return result;
     }
 
     @Override
-    protected void onRestoreInstanceState(@NonNull final Parcelable state) {
-        final SavedState savedState = (SavedState) state;
-        final Parcelable superSavedState = savedState.getSuperState();
+    protected void onRestoreInstanceState(@Nullable final Parcelable state) {
+        final Bundle savedState = (Bundle) state;
 
-        super.onRestoreInstanceState(superSavedState);
+        if (savedState != null) {
+            final Parcelable superSavedState = savedState.getParcelable(SUPER_STATE_KEY);
+            super.onRestoreInstanceState(superSavedState);
 
-        applyConfig(savedState.config);
+            final CustomLayoutPromptViewConfig config
+                    = savedState.getParcelable(CUSTOM_LAYOUT_PROMPT_VIEW_CONFIG_KEY);
 
-        restorePresenterState(superSavedState);
+            if (config != null) {
+                applyConfig(config);
+            }
+
+            restorePresenterState(superSavedState);
+        }
     }
 
     @Override
@@ -116,42 +128,6 @@ public final class CustomLayoutPromptView
         config = new CustomLayoutPromptViewConfig(typedArray);
 
         typedArray.recycle();
-    }
-
-    private static class SavedState extends BaseSavedState {
-
-        private CustomLayoutPromptViewConfig config;
-
-        protected SavedState(final Parcelable superState) {
-            super(superState);
-        }
-
-        protected SavedState(final Parcel in) {
-            super(in);
-            config = in.readParcelable(getClass().getClassLoader());
-        }
-
-        @Override
-        public void writeToParcel(final Parcel out, final int flags) {
-            super.writeToParcel(out, flags);
-            out.writeParcelable(config, flags);
-        }
-
-        public static final Parcelable.Creator<SavedState> CREATOR
-                = new Parcelable.Creator<SavedState>() {
-
-            @Override
-            public SavedState createFromParcel(final Parcel in) {
-                return new SavedState(in);
-            }
-
-            @Override
-            public SavedState[] newArray(final int size) {
-                return new SavedState[size];
-            }
-
-        };
-
     }
 
 }

--- a/amplify/src/main/java/com/github/stkent/amplify/prompt/DefaultLayoutPromptView.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/prompt/DefaultLayoutPromptView.java
@@ -18,7 +18,7 @@ package com.github.stkent.amplify.prompt;
 
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.os.Parcel;
+import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -28,7 +28,11 @@ import com.github.stkent.amplify.R;
 import com.github.stkent.amplify.prompt.interfaces.IPromptView;
 
 public final class DefaultLayoutPromptView
-        extends BasePromptView<DefaultLayoutQuestionView, DefaultLayoutThanksView> implements IPromptView {
+        extends BasePromptView<DefaultLayoutQuestionView, DefaultLayoutThanksView>
+        implements IPromptView {
+
+    private static final String DEFAULT_LAYOUT_PROMPT_VIEW_CONFIG_KEY
+            = "DEFAULT_LAYOUT_PROMPT_VIEW_CONFIG_KEY";
 
     // NonNull
     private DefaultLayoutPromptViewConfig config;
@@ -65,21 +69,30 @@ public final class DefaultLayoutPromptView
     @Override
     protected Parcelable onSaveInstanceState() {
         final Parcelable superState = super.onSaveInstanceState();
-        final SavedState savedState = new SavedState(superState);
-        savedState.config = config;
-        return savedState;
+
+        final Bundle result = new Bundle();
+        result.putParcelable(SUPER_STATE_KEY, superState);
+        result.putParcelable(DEFAULT_LAYOUT_PROMPT_VIEW_CONFIG_KEY, config);
+        return result;
     }
 
     @Override
-    protected void onRestoreInstanceState(@NonNull final Parcelable state) {
-        final SavedState savedState = (SavedState) state;
-        final Parcelable superSavedState = savedState.getSuperState();
+    protected void onRestoreInstanceState(@Nullable final Parcelable state) {
+        final Bundle savedState = (Bundle) state;
 
-        super.onRestoreInstanceState(savedState.getSuperState());
+        if (savedState != null) {
+            final Parcelable superSavedState = savedState.getParcelable(SUPER_STATE_KEY);
+            super.onRestoreInstanceState(superSavedState);
 
-        applyConfig(savedState.config);
+            final DefaultLayoutPromptViewConfig config
+                    = savedState.getParcelable(DEFAULT_LAYOUT_PROMPT_VIEW_CONFIG_KEY);
 
-        restorePresenterState(superSavedState);
+            if (config != null) {
+                applyConfig(config);
+            }
+
+            restorePresenterState(superSavedState);
+        }
     }
 
     @Override
@@ -112,42 +125,6 @@ public final class DefaultLayoutPromptView
         config = new DefaultLayoutPromptViewConfig(typedArray);
 
         typedArray.recycle();
-    }
-
-    private static class SavedState extends BaseSavedState {
-
-        private DefaultLayoutPromptViewConfig config;
-
-        protected SavedState(final Parcelable superState) {
-            super(superState);
-        }
-
-        protected SavedState(final Parcel in) {
-            super(in);
-            config = in.readParcelable(getClass().getClassLoader());
-        }
-
-        @Override
-        public void writeToParcel(final Parcel out, final int flags) {
-            super.writeToParcel(out, flags);
-            out.writeParcelable(config, flags);
-        }
-
-        public static final Parcelable.Creator<SavedState> CREATOR
-                = new Parcelable.Creator<SavedState>() {
-
-            @Override
-            public SavedState createFromParcel(final Parcel in) {
-                return new SavedState(in);
-            }
-
-            @Override
-            public SavedState[] newArray(final int size) {
-                return new SavedState[size];
-            }
-
-        };
-
     }
 
 }

--- a/amplify/src/main/java/com/github/stkent/amplify/prompt/interfaces/IPromptPresenter.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/prompt/interfaces/IPromptPresenter.java
@@ -51,6 +51,6 @@ public interface IPromptPresenter extends IEventListener {
     @NonNull
     Bundle generateStateBundle();
 
-    void restoreStateFromBundle(final Bundle bundle);
+    void restoreStateFromBundle(@NonNull final Bundle bundle);
 
 }


### PR DESCRIPTION
#### Issue Link
<!-- (Required) Link to GitHub issue/JIRA card/Trello card -->

#146

Note that #148 was discovered while implementing this fix, but it is not resolved by this PR.

#### Goals
<!-- (Required) Summarize the goals of this PR -->

Fix crash when restoring view state.

#### Implementation Notes
<!-- (Optional) Highlight any new utility code -->
<!-- (Optional) Highlight tricky decisions and explain your choices  -->

This change completely removes `BaseSavedState` from the code base. We cast the provided `Parcelable` instances to `Bundle`s, and write/read all required state manually.

#### Testing Notes
<!-- (Required) List steps to test this PR manually -->

From #147 

> To test this you can open the example application and then click the home button. After home screening the app you must cause it to be removed from memory which will save the state of the views. You can do this by going to the AndroidMonitor tab in Android Studio and clicking the red X (Terminate Application) on the left side of the screen. Then just open the app on your device and it will attempt to restore the view state. With the current version this will crash.
> 
> **Note:** One thing to check in this PR is that it still saves all the state it should.