### PR TITLE
Fix state restoration when multiple prompt views are used in a single screen

### DIFF
--- a/amplify/src/main/java/com/github/stkent/amplify/prompt/BasePromptView.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/prompt/BasePromptView.java
@@ -51,6 +51,7 @@ abstract class BasePromptView<T extends View & IQuestionView, U extends View & I
 
     protected static final String SUPER_STATE_KEY = "SUPER_STATE_KEY";
     private static final String THANKS_DISPLAY_TIME_EXPIRED_KEY = "THANKS_DISPLAY_TIME_EXPIRED_KEY";
+    private static final String BASE_PROMPT_VIEW_CONFIG_KEY = "BASE_PROMPT_VIEW_CONFIG_KEY";
     private static final String PROMPT_PRESENTER_STATE_BUNDLE_KEY
             = "PROMPT_PRESENTER_STATE_BUNDLE_KEY";
 
@@ -122,6 +123,7 @@ abstract class BasePromptView<T extends View & IQuestionView, U extends View & I
 
         final Bundle result = new Bundle();
         result.putParcelable(SUPER_STATE_KEY, superState);
+        result.putParcelable(BASE_PROMPT_VIEW_CONFIG_KEY, basePromptViewConfig);
         result.putBoolean(THANKS_DISPLAY_TIME_EXPIRED_KEY, thanksDisplayTimeExpired);
         result.putBundle(PROMPT_PRESENTER_STATE_BUNDLE_KEY, promptPresenter.generateStateBundle());
         return result;
@@ -135,6 +137,13 @@ abstract class BasePromptView<T extends View & IQuestionView, U extends View & I
         if (savedState != null) {
             final Parcelable superSavedState = savedState.getParcelable(SUPER_STATE_KEY);
             super.onRestoreInstanceState(superSavedState);
+
+            final BasePromptViewConfig config
+                    = savedState.getParcelable(BASE_PROMPT_VIEW_CONFIG_KEY);
+
+            if (config != null) {
+                applyBaseConfig(config);
+            }
 
             thanksDisplayTimeExpired = savedState.getBoolean(THANKS_DISPLAY_TIME_EXPIRED_KEY);
         }

--- a/amplify/src/main/java/com/github/stkent/amplify/prompt/BasePromptView.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/prompt/BasePromptView.java
@@ -25,6 +25,7 @@ import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
+import android.util.SparseArray;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
@@ -137,6 +138,16 @@ abstract class BasePromptView<T extends View & IQuestionView, U extends View & I
 
             thanksDisplayTimeExpired = savedState.getBoolean(THANKS_DISPLAY_TIME_EXPIRED_KEY);
         }
+    }
+
+    @Override
+    protected void dispatchSaveInstanceState(final SparseArray<Parcelable> container) {
+        super.dispatchFreezeSelfOnly(container);
+    }
+
+    @Override
+    protected void dispatchRestoreInstanceState(final SparseArray<Parcelable> container) {
+        super.dispatchThawSelfOnly(container);
     }
 
     @NonNull


### PR DESCRIPTION
#### Issue Link
<!-- (Required) Link to GitHub issue/JIRA card/Trello card -->

#148

**Includes #149; do not merge before that PR!**

#### Testing Notes
<!-- (Required) List steps to test this PR manually -->

- Build and run test app
- Note question title/subtitle in third prompt
- Rotate device
- Observe that question title/subtitle in third prompt are unchanged in this branch.

#### Videos/Screenshots
<!-- (Required when applicable) Show UI before & after changes -->

![vidcap 2016-04-11 at 21 50 54 pm](https://cloud.githubusercontent.com/assets/6463980/14447654/b210fbd4-002f-11e6-8e3e-a6d4b5da88b0.gif)
