### PR TITLE
Add app install source to default email feedback

### DIFF
--- a/amplify/config/pmd.xml
+++ b/amplify/config/pmd.xml
@@ -73,6 +73,7 @@
 
     <rule ref="rulesets/java/junit.xml">
         <exclude name="JUnitTestsShouldIncludeAssert" />
+        <exclude name="JUnitTestContainsTooManyAsserts" />
     </rule>
 
     <rule ref="rulesets/java/logging-jakarta-commons.xml">

--- a/amplify/src/main/java/com/github/stkent/amplify/App.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/App.java
@@ -36,16 +36,21 @@ public final class App implements IApp {
 
     private final long lastUpdateTime;
 
+    @NonNull
+    private final InstallSource installSource;
+
     public App(@NonNull final Context context) {
         final PackageManager packageManager = context.getPackageManager();
         final ApplicationInfo applicationInfo = context.getApplicationInfo();
         final PackageInfo packageInfo = getPackageInfo(context);
+        final String installerPackageName = packageManager.getInstallerPackageName(context.getPackageName());
 
         name = applicationInfo.loadLabel(packageManager).toString();
         versionName = packageInfo.versionName;
         versionCode = packageInfo.versionCode;
         firstInstallTime = packageInfo.firstInstallTime;
         lastUpdateTime = packageInfo.lastUpdateTime;
+        installSource = InstallSource.fromInstallerPackageName(installerPackageName);
     }
 
     @NonNull
@@ -71,6 +76,12 @@ public final class App implements IApp {
     @Override
     public long getLastUpdateTime() {
         return lastUpdateTime;
+    }
+
+    @NonNull
+    @Override
+    public InstallSource getInstallSource() {
+        return installSource;
     }
 
     @NonNull

--- a/amplify/src/main/java/com/github/stkent/amplify/Environment.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/Environment.java
@@ -29,19 +29,10 @@ import java.util.List;
 
 import static android.content.pm.PackageManager.GET_ACTIVITIES;
 import static android.content.pm.PackageManager.MATCH_DEFAULT_ONLY;
+import static com.github.stkent.amplify.utils.Constants.AMAZON_APP_STORE_PACKAGE_NAME;
+import static com.github.stkent.amplify.utils.Constants.GOOGLE_PLAY_STORE_PACKAGE_NAME;
 
 public final class Environment implements IEnvironment {
-
-    /**
-     * Package name for the Amazon App Store.
-     */
-    private static final String AMAZON_APP_STORE_PACKAGE_NAME = "com.amazon.venezia";
-
-    /**
-     * Package name for the Google Play Store. Value can be verified here:
-     * https://developers.google.com/android/reference/com/google/android/gms/common/GooglePlayServicesUtil.html#GOOGLE_PLAY_STORE_PACKAGE
-     */
-    private static final String GOOGLE_PLAY_STORE_PACKAGE_NAME = "com.android.vending";
 
     @NonNull
     private final Context appContext;

--- a/amplify/src/main/java/com/github/stkent/amplify/IApp.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/IApp.java
@@ -32,4 +32,7 @@ public interface IApp {
 
     long getLastUpdateTime();
 
+    @NonNull
+    InstallSource getInstallSource();
+
 }

--- a/amplify/src/main/java/com/github/stkent/amplify/InstallSource.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/InstallSource.java
@@ -1,0 +1,89 @@
+package com.github.stkent.amplify;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import static com.github.stkent.amplify.utils.Constants.AMAZON_APP_STORE_PACKAGE_NAME;
+import static com.github.stkent.amplify.utils.Constants.AMAZON_UNDERGROUND_PACKAGE_NAME;
+import static com.github.stkent.amplify.utils.Constants.GOOGLE_PLAY_STORE_PACKAGE_NAME;
+import static com.github.stkent.amplify.utils.Constants.PACKAGE_INSTALLER_PACKAGE_NAME;
+
+/*
+ * An attempt to make an Algebraic data type in Java (https://en.wikipedia.org/wiki/Algebraic_data_type). See also
+ * https://grundlefleck.github.io/2014/07/17/sealing-algebraic-data-types-in-java.html
+ */
+public abstract class InstallSource {
+
+    @NonNull
+    /* default */ static InstallSource fromInstallerPackageName(@Nullable final String installerPackageName) {
+        if (GOOGLE_PLAY_STORE_PACKAGE_NAME.equalsIgnoreCase(installerPackageName)) {
+            return new GooglePlayStoreInstallSource();
+        } else if (AMAZON_APP_STORE_PACKAGE_NAME.equalsIgnoreCase(installerPackageName)) {
+            return new AmazonAppStoreInstallSource();
+        } else if (AMAZON_UNDERGROUND_PACKAGE_NAME.equalsIgnoreCase(installerPackageName)) {
+            return new AmazonUndergroundInstallSource();
+        } else if (PACKAGE_INSTALLER_PACKAGE_NAME.equalsIgnoreCase(installerPackageName)) {
+            return new PackageInstallerInstallSource();
+        } else if (installerPackageName != null) {
+            return new UnrecognizedInstallSource(installerPackageName);
+        } else {
+            return new UnknownInstallSource();
+        }
+    }
+
+    private InstallSource() {
+        // This constructor intentionally left blank.
+    }
+
+    public static final class GooglePlayStoreInstallSource extends InstallSource {
+        @Override
+        public String toString() {
+            return "Google Play Store";
+        }
+    }
+
+    public static final class AmazonAppStoreInstallSource extends InstallSource {
+        @Override
+        public String toString() {
+            return "Amazon Appstore";
+        }
+    }
+
+    public static final class AmazonUndergroundInstallSource extends InstallSource {
+        @Override
+        public String toString() {
+            return "Amazon Underground";
+        }
+    }
+
+    public static final class PackageInstallerInstallSource extends InstallSource {
+        @Override
+        public String toString() {
+            return "Package Installer";
+        }
+    }
+
+    public static final class UnknownInstallSource extends InstallSource {
+        @Override
+        public String toString() {
+            return "Unknown";
+        }
+    }
+
+    public static final class UnrecognizedInstallSource extends InstallSource {
+
+        @NonNull
+        private final String installerPackageName;
+
+        private UnrecognizedInstallSource(@NonNull final String installerPackageName) {
+            this.installerPackageName = installerPackageName;
+        }
+
+        @Override
+        public String toString() {
+            return installerPackageName;
+        }
+
+    }
+
+}

--- a/amplify/src/main/java/com/github/stkent/amplify/InstallSource.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/InstallSource.java
@@ -41,7 +41,7 @@ public abstract class InstallSource {
         } else if (PACKAGE_INSTALLER_PACKAGE_NAME.equalsIgnoreCase(installerPackageName)) {
             return new PackageInstallerInstallSource();
         } else if (installerPackageName != null) {
-            return new UnrecognizedInstallSource(installerPackageName);
+            return new UnrecognizedInstallSource(installerPackageName); // NOPMD: required as part of algebraic type.
         } else {
             return new UnknownInstallSource();
         }
@@ -91,6 +91,7 @@ public abstract class InstallSource {
         @NonNull
         private final String installerPackageName;
 
+        @SuppressWarnings("PMD.CallSuperInConstructor") // Super does nothing.
         private UnrecognizedInstallSource(@NonNull final String installerPackageName) {
             this.installerPackageName = installerPackageName;
         }

--- a/amplify/src/main/java/com/github/stkent/amplify/InstallSource.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/InstallSource.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2015 Stuart Kent
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.github.stkent.amplify;
 
 import android.support.annotation.NonNull;

--- a/amplify/src/main/java/com/github/stkent/amplify/feedback/DefaultEmailFeedbackCollector.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/feedback/DefaultEmailFeedbackCollector.java
@@ -58,6 +58,7 @@ public class DefaultEmailFeedbackCollector extends BaseEmailFeedbackCollector {
         // @formatter:off
         return    "Time Stamp: " + getCurrentUtcTimeStringForDate(new Date()) + "\n"
                 + "App Version: " + appVersionString + "\n"
+                + "Install Source: " + app.getInstallSource() + "\n"
                 + "Android Version: " + androidVersionString + "\n"
                 + "Device Manufacturer: " + device.getManufacturer() + "\n"
                 + "Device Model: " + device.getModel() + "\n"

--- a/amplify/src/main/java/com/github/stkent/amplify/utils/Constants.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/utils/Constants.java
@@ -18,6 +18,32 @@ package com.github.stkent.amplify.utils;
 
 public final class Constants {
 
+    /**
+     * Package name for the Amazon App Store.
+     */
+    public static final String AMAZON_APP_STORE_PACKAGE_NAME = "com.amazon.venezia";
+
+    /**
+     * Package name for Amazon Underground.
+     */
+    public static final String AMAZON_UNDERGROUND_PACKAGE_NAME = "com.amazon.mshop.android";
+
+    /**
+     * Package name for the Google Play Store. Value can be verified here:
+     * https://developers.google.com/android/reference/com/google/android/gms/common/GooglePlayServicesUtil.html#GOOGLE_PLAY_STORE_PACKAGE
+     */
+    public static final String GOOGLE_PLAY_STORE_PACKAGE_NAME = "com.android.vending";
+
+    /**
+     * Package name for Google's Package Installer. My guess is that apps installed using the
+     * <a href="https://developer.android.com/reference/android/content/pm/PackageInstaller.html">PackageInstaller</a>
+     * APIs will report as having been installed from this source. Since this installer package name result hides the
+     * originating app package name from us, a consuming application that *really* needs to know how an app was
+     * installed will need to fall back on inspecting the apps currently installed on the device and making an educated
+     * guess.
+     */
+    public static final String PACKAGE_INSTALLER_PACKAGE_NAME = "com.google.android.packageinstaller";
+
     public static final String EXHAUSTIVE_SWITCH_EXCEPTION_MESSAGE
             = "This switch statement should be exhaustive.";
 

--- a/amplify/src/test/java/com/github/stkent/amplify/InstallSourceTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/InstallSourceTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2015 Stuart Kent
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.github.stkent.amplify;
+
+import com.github.stkent.amplify.InstallSource.AmazonAppStoreInstallSource;
+import com.github.stkent.amplify.InstallSource.AmazonUndergroundInstallSource;
+import com.github.stkent.amplify.InstallSource.GooglePlayStoreInstallSource;
+import com.github.stkent.amplify.InstallSource.PackageInstallerInstallSource;
+import com.github.stkent.amplify.InstallSource.UnknownInstallSource;
+import com.github.stkent.amplify.InstallSource.UnrecognizedInstallSource;
+import com.github.stkent.amplify.helpers.BaseTest;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class InstallSourceTest extends BaseTest {
+
+    @Test
+    public void testGooglePlayStoreInstallSourceIsParsedCorrectly() {
+        // Act
+        final InstallSource installSource = InstallSource.fromInstallerPackageName("com.android.vending");
+
+        // Assert
+        assertTrue(installSource instanceof GooglePlayStoreInstallSource);
+        assertEquals("Google Play Store", installSource.toString());
+    }
+
+    @Test
+    public void testAmazonAppStoreInstallSourceIsParsedCorrectly() {
+        // Act
+        InstallSource installSource = InstallSource.fromInstallerPackageName("com.amazon.venezia");
+
+        // Assert
+        assertTrue(installSource instanceof AmazonAppStoreInstallSource);
+        assertEquals("Amazon Appstore", installSource.toString());
+    }
+
+    @Test
+    public void testAmazonUndergroundInstallSourceIsParsedCorrectly() {
+        // Act
+        final InstallSource installSource = InstallSource.fromInstallerPackageName("com.amazon.mshop.android");
+
+        // Assert
+        assertTrue(installSource instanceof AmazonUndergroundInstallSource);
+        assertEquals("Amazon Underground", installSource.toString());
+    }
+
+    @Test
+    public void testPackageInstallerInstallSourceIsParsedCorrectly() {
+        // Act
+        final InstallSource installSource = InstallSource.fromInstallerPackageName("com.google.android.packageinstaller");
+
+        // Assert
+        assertTrue(installSource instanceof PackageInstallerInstallSource);
+        assertEquals("Package Installer", installSource.toString());
+    }
+
+    @Test
+    public void testUnrecognizedInstallSourceIsParsedCorrectly() {
+        // Arrange
+        final String unrecognizedInstallerPackageName = "com.unrecognized";
+
+        // Act
+        final InstallSource installSource = InstallSource.fromInstallerPackageName(unrecognizedInstallerPackageName);
+
+        // Assert
+        assertTrue(installSource instanceof UnrecognizedInstallSource);
+        assertEquals(unrecognizedInstallerPackageName, installSource.toString());
+    }
+
+
+    @Test
+    public void testUnknownInstallSourceIsParsedCorrectly() {
+        // Act
+        final InstallSource installSource = InstallSource.fromInstallerPackageName(null);
+
+        // Assert
+        assertTrue(installSource instanceof UnknownInstallSource);
+        assertEquals("Unknown", installSource.toString());
+    }
+
+}

--- a/amplify/src/test/java/com/github/stkent/amplify/InstallSourceTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/InstallSourceTest.java
@@ -27,6 +27,7 @@ import com.github.stkent.amplify.helpers.BaseTest;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+
 import static org.junit.Assert.assertTrue;
 
 public class InstallSourceTest extends BaseTest {
@@ -37,8 +38,14 @@ public class InstallSourceTest extends BaseTest {
         final InstallSource installSource = InstallSource.fromInstallerPackageName("com.android.vending");
 
         // Assert
-        assertTrue(installSource instanceof GooglePlayStoreInstallSource);
-        assertEquals("Google Play Store", installSource.toString());
+        assertTrue(
+                "Package name is correctly identified as belonging to the Google Play Store",
+                installSource instanceof GooglePlayStoreInstallSource);
+
+        assertEquals(
+                "Google Play Store install source has correct description",
+                "Google Play Store",
+                installSource.toString());
     }
 
     @Test
@@ -47,8 +54,14 @@ public class InstallSourceTest extends BaseTest {
         InstallSource installSource = InstallSource.fromInstallerPackageName("com.amazon.venezia");
 
         // Assert
-        assertTrue(installSource instanceof AmazonAppStoreInstallSource);
-        assertEquals("Amazon Appstore", installSource.toString());
+        assertTrue(
+                "Package name is correctly identified as belonging to the Amazon Appstore",
+                installSource instanceof AmazonAppStoreInstallSource);
+
+        assertEquals(
+                "Amazon Appstore install source has correct description",
+                "Amazon Appstore",
+                installSource.toString());
     }
 
     @Test
@@ -57,8 +70,14 @@ public class InstallSourceTest extends BaseTest {
         final InstallSource installSource = InstallSource.fromInstallerPackageName("com.amazon.mshop.android");
 
         // Assert
-        assertTrue(installSource instanceof AmazonUndergroundInstallSource);
-        assertEquals("Amazon Underground", installSource.toString());
+        assertTrue(
+                "Package name is correctly identified as belonging to Amazon Underground",
+                installSource instanceof AmazonUndergroundInstallSource);
+
+        assertEquals(
+                "Amazon Underground install source has correct description",
+                "Amazon Underground",
+                installSource.toString());
     }
 
     @Test
@@ -67,8 +86,14 @@ public class InstallSourceTest extends BaseTest {
         final InstallSource installSource = InstallSource.fromInstallerPackageName("com.google.android.packageinstaller");
 
         // Assert
-        assertTrue(installSource instanceof PackageInstallerInstallSource);
-        assertEquals("Package Installer", installSource.toString());
+        assertTrue(
+                "Package name is correctly identified as belonging to the Android Package Installer",
+                installSource instanceof PackageInstallerInstallSource);
+
+        assertEquals(
+                "Package Installer install source has correct description",
+                "Package Installer",
+                installSource.toString());
     }
 
     @Test
@@ -80,8 +105,14 @@ public class InstallSourceTest extends BaseTest {
         final InstallSource installSource = InstallSource.fromInstallerPackageName(unrecognizedInstallerPackageName);
 
         // Assert
-        assertTrue(installSource instanceof UnrecognizedInstallSource);
-        assertEquals(unrecognizedInstallerPackageName, installSource.toString());
+        assertTrue(
+                "Non-null package name is correctly identified as an unrecognized install source",
+                installSource instanceof UnrecognizedInstallSource);
+
+        assertEquals(
+                "Unrecognized install source returns raw package name as description",
+                unrecognizedInstallerPackageName,
+                installSource.toString());
     }
 
 
@@ -91,8 +122,14 @@ public class InstallSourceTest extends BaseTest {
         final InstallSource installSource = InstallSource.fromInstallerPackageName(null);
 
         // Assert
-        assertTrue(installSource instanceof UnknownInstallSource);
-        assertEquals("Unknown", installSource.toString());
+        assertTrue(
+                "null package name is correctly identified as an unknown install source",
+                installSource instanceof UnknownInstallSource);
+
+        assertEquals(
+                "Unknown install source has correct description",
+                "Unknown",
+                installSource.toString());
     }
 
 }

--- a/amplify/src/test/java/com/github/stkent/amplify/utils/StringUtilsTest.java
+++ b/amplify/src/test/java/com/github/stkent/amplify/utils/StringUtilsTest.java
@@ -90,7 +90,8 @@ public class StringUtilsTest extends BaseTest {
         // Assert
         assertEquals(
                 "defaultIfBlank should have returned the default string",
-                DEFAULT_STRING, sanitizedString);
+                DEFAULT_STRING,
+                sanitizedString);
     }
 
 }


### PR DESCRIPTION
@alexeyvasilyev this information is also accessible to general IFeedbackCollector implementations, thought it might be useful for you. I don't think I want to bake a check for install source into the provided Amazon/Google feedback collectors, but with this new typed API you should be able to write your own quite easily now!