### PR TITLE
Fix buttons background for devices with <=17 API

### DIFF
--- a/amplify/src/main/java/com/github/stkent/amplify/prompt/DefaultLayoutQuestionView.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/prompt/DefaultLayoutQuestionView.java
@@ -169,11 +169,15 @@ final class DefaultLayoutQuestionView extends CustomLayoutQuestionView {
         final Drawable buttonBackgroundDrawable
                 = getButtonBackgroundDrawable(fillColor, borderColor, borderWidthPx, cornerRadiusPx);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+
+        if (android.os.Build.VERSION.SDK_INT <= 17) {
+            GradientDrawable gd = new GradientDrawable();
+            gd.setColor(fillColor);
+            gd.setCornerRadius(cornerRadiusPx);
+            gd.setStroke(borderWidthPx,borderColor);
+            button.setBackgroundDrawable(gd);
+        }else{
             button.setBackground(buttonBackgroundDrawable);
-        } else {
-            //noinspection deprecation
-            button.setBackgroundDrawable(buttonBackgroundDrawable);
         }
     }
 

--- a/amplify/src/main/java/com/github/stkent/amplify/prompt/DefaultLayoutQuestionView.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/prompt/DefaultLayoutQuestionView.java
@@ -22,6 +22,7 @@ import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.LayerDrawable;
 import android.graphics.drawable.ShapeDrawable;
+import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.StateListDrawable;
 import android.graphics.drawable.shapes.RoundRectShape;
 import android.os.Build;

--- a/amplify/src/main/java/com/github/stkent/amplify/prompt/DefaultLayoutQuestionView.java
+++ b/amplify/src/main/java/com/github/stkent/amplify/prompt/DefaultLayoutQuestionView.java
@@ -177,7 +177,12 @@ final class DefaultLayoutQuestionView extends CustomLayoutQuestionView {
             gd.setCornerRadius(cornerRadiusPx);
             gd.setStroke(borderWidthPx,borderColor);
             button.setBackgroundDrawable(gd);
-        }else{
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.JELLY_BEAN) {
+                button.setBackgroundDrawable(gd);
+            }else{
+                button.setBackground(gd);
+            }
+            }else{
             button.setBackground(buttonBackgroundDrawable);
         }
     }


### PR DESCRIPTION
For devices with  <=17 API :
**Before**
![screenshot_1512492011](https://user-images.githubusercontent.com/11445928/33676685-1a14d2a8-dabf-11e7-8275-b60b04e63f4d.png)
**After**
![screenshot_1512582622](https://user-images.githubusercontent.com/11445928/33676696-22af846c-dabf-11e7-8847-c5f2842b5b10.png)

I know Pull requests from external contributors are not currently being accepted but I'll let it here maybe in the future you can add it if you want